### PR TITLE
VSCode設定の修正

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,4 +1,0 @@
-{
-  "recommendations": ["standard.vscode-standard"],
-  "unwantedRecommendations": []
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,5 @@
 {
   "editor.tabSize": 2,
   "editor.insertSpaces": true,
-  "editor.detectIndentation": false,
-  "files.autoSave": "onFocusChange",
-  "standard.autoFixOnSave": true,
-  "standard.engine": "ts-standard"
+  "editor.detectIndentation": false
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "packageManager": "yarn@3.2.0",
   "license": "MIT",
   "scripts": {
-    "start": "node src/index.js"
+    "start": "node src/index.js",
+    "test": "standard"
   },
   "devDependencies": {
     "standard": "16.0.4"


### PR DESCRIPTION
standard.vscode-standard の動作のために node_modules/ が必要だったので使用しないようにした
代わりに `yarn test` で `standard` が走るようにした